### PR TITLE
Fix "calling 'GetName' on bad self"

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -1287,7 +1287,13 @@ end
 
 function ItemRack.MenuMouseover()
 	local frame = GetMouseFocus()
-	if MouseIsOver(ItemRackMenuFrame) or IsShiftKeyDown() or (frame and frame:GetName() and frame:IsVisible() and ItemRack.MenuMouseoverFrames[frame:GetName()]) then
+	local frameName = nil
+	local frameVisible = nil
+	local IRmouseOverFrame = nil
+	if frame then frameName = frame:GetName() end
+	if frame then frameVisible = frame:IsVisible() end
+	if frameName then IRmouseOverFrame = ItemRack.MenuMouseoverFrames[frameName] end
+	if MouseIsOver(ItemRackMenuFrame) or IsShiftKeyDown() or (frame and frameName and frameVisible and IRmouseOverFrame) then
 		return -- keep menu open if mouse over menu, shift is down or mouse is immediately over a mouseover frame
 	end
 	for i in pairs(ItemRack.MenuMouseoverFrames) do


### PR DESCRIPTION
In 4.1+ clients, which all modern and classic WoW clients are long descedents from (all clients are 10.0+ now), GetMouseFocus() can return nil when opening character frames (player or others like inspecting).  This fixes calling GetName in those situations.  Its probably a little overkill, but it works.